### PR TITLE
added missing fields$ arguments in select statement

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "HISTORY.md",
     "LICENSE.txt",
     "mysql-store.js",
+    "query-builder.js",
     "package.json",
     "default_config.json"
   ],

--- a/query-builder.js
+++ b/query-builder.js
@@ -29,8 +29,14 @@ function whereargs (qent, q) {
 }
 
 function selectargs (q) {
-    var sa = q.fields$.join(',')
-    return sa
+  var fields = q.fields$
+  var sa
+  if(fields && fields.length > 0) {
+    sa = fields.join(',')
+  } else {
+    sa = '*'
+  }
+  return sa
 }
 
 function selectstm (qent, q) {
@@ -49,9 +55,9 @@ function selectstm (qent, q) {
   var mq = metaquery(qent, q)
   var metastr = ' ' + mq.join(' ')
 
-  var selectargs = selectargs(q)
+  var selectstr = selectargs(q)
 
-  return 'SELECT ' + selectargs + ' FROM ' + table + wherestr + metastr
+  return 'SELECT ' + selectstr + ' FROM ' + table + wherestr + metastr
 }
 
 function tablename (entity) {

--- a/query-builder.js
+++ b/query-builder.js
@@ -31,11 +31,14 @@ function whereargs (qent, q) {
 function selectargs (q) {
   var fields = q.fields$
   var sa
-  if(fields && fields.length > 0) {
+
+  if (fields && fields.length > 0) {
     sa = fields.join(',')
-  } else {
+  }
+  else {
     sa = '*'
   }
+
   return sa
 }
 

--- a/query-builder.js
+++ b/query-builder.js
@@ -28,6 +28,11 @@ function whereargs (qent, q) {
   return w
 }
 
+function selectargs (q) {
+    var sa = q.fields$.join(',')
+    return sa
+}
+
 function selectstm (qent, q) {
   var table = tablename(qent)
   var params = []
@@ -44,7 +49,9 @@ function selectstm (qent, q) {
   var mq = metaquery(qent, q)
   var metastr = ' ' + mq.join(' ')
 
-  return 'SELECT * FROM ' + table + wherestr + metastr
+  var selectargs = selectargs(q)
+
+  return 'SELECT ' + selectargs + ' FROM ' + table + wherestr + metastr
 }
 
 function tablename (entity) {

--- a/test/dbconfig.example.js
+++ b/test/dbconfig.example.js
@@ -3,7 +3,7 @@
 module.exports = {
   name: 'senecatest',
   host: 'localhost',
-  user: 'root',
-  password: '',
+  user: 'senecatest',
+  password: 'senecatest',
   port: 3306
 }

--- a/test/dbconfig.example.js
+++ b/test/dbconfig.example.js
@@ -3,7 +3,7 @@
 module.exports = {
   name: 'senecatest',
   host: 'localhost',
-  user: 'senecatest',
-  password: 'senecatest',
+  user: 'root',
+  password: '',
   port: 3306
 }


### PR DESCRIPTION
queries like ent.list$({..., fields$: ['f1', 'f2', ...], ...}, ...) work now
refers to issue #29
